### PR TITLE
Implement configrepo plugin fetch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,28 @@ set -e
 
 go get github.com/mitchellh/go-homedir \
   github.com/spf13/cobra \
-  github.com/spf13/viper
+  github.com/spf13/viper \
+  github.com/blang/semver \
+  github.com/dustin/go-humanize
 
 rm -f gocd
+
+for arg in $@; do
+  case $arg in
+    --skip-tests)
+      skip=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ "true" = "$skip" ]]; then
+  echo "Skipping tests"
+else
+   go test ./...
+fi
+
 go build -o gocd main.go

--- a/cmd/configrepo/fetch.go
+++ b/cmd/configrepo/fetch.go
@@ -1,0 +1,86 @@
+package configrepo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/gocd-contrib/gocd-cli/dub"
+	"github.com/gocd-contrib/gocd-cli/github"
+	"github.com/gocd-contrib/gocd-cli/plugins"
+	"github.com/gocd-contrib/gocd-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var FetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Fetches configrepo plugins",
+	Run: func(cmd *cobra.Command, args []string) {
+		runFetch(args)
+	},
+}
+
+var stableOnly bool
+var filterBy string
+
+func runFetch(args []string) {
+	if "" == PluginId {
+		utils.DieLoudly(1, "You must provide a --plugin-id")
+	}
+
+	if _, err := FetchPlugin(PluginId); err != nil {
+		utils.AbortLoudly(err)
+	}
+}
+
+func FetchPlugin(id string) (string, error) {
+	releases := make([]github.Release, 0)
+
+	if err := dub.New().Get(url(PluginId)).Do(func(res *dub.Response) error {
+		payload, err := res.ReadAll()
+
+		if err != nil {
+			return err
+		}
+
+		return json.Unmarshal(payload, &releases)
+	}); nil != err {
+		return "", err
+	}
+
+	if 0 == len(releases) {
+		return "", fmt.Errorf("There are no available releases for %s", id)
+	}
+
+	if a, err := github.ResolveVersionJar(releases, filterBy, stableOnly); err != nil {
+		return "", err
+	} else {
+		if existing := plugins.PluginById(PluginId, PluginDir); "" != existing {
+			if utils.IsDir(existing) {
+				utils.Errfln("[WARNING] `%s` is a directory; will not remove this, but please inspect.", existing)
+			}
+
+			if utils.IsFile(existing) {
+				utils.Echofln("Removing existing %s plugin %s", PluginId, existing)
+				os.RemoveAll(existing)
+			}
+		}
+
+		return utils.Wget(a.Url, a.Name, PluginDir)
+	}
+}
+
+func url(pluginId string) (releaseUrl string) {
+	if v, ok := plugins.ConfigRepo[PluginId]; ok {
+		releaseUrl = v.Url
+	} else {
+		utils.DieLoudly(1, "Don't know how to fetch plugin `%s`; known plugins: %s", pluginId, plugins.ConfigRepo.ShortList())
+	}
+	return
+}
+
+func init() {
+	FetchCmd.Flags().BoolVar(&stableOnly, "stable", false, "Restrict to stable (i.e., non-prerelease) releases")
+	FetchCmd.Flags().StringVar(&filterBy, "match-version", "", "Specify a semver exact match, range (e.g., >=1.0.0 <2.0.0 || >=3.0.0 !3.0.1-beta.1), or wildcard (e.g., 0.8.x)")
+	RootCmd.AddCommand(FetchCmd)
+}

--- a/cmd/configrepo/root.go
+++ b/cmd/configrepo/root.go
@@ -15,9 +15,10 @@ var PluginJar string
 
 // RootCmd represents the configrepo command
 var RootCmd = &cobra.Command{
-	Use:   "configrepo",
-	Short: "GoCD config-repo functions",
-	Long:  `Functions to help development of config-repos in GoCD (pipeline configs as code)`,
+	Use:       "configrepo",
+	Short:     "GoCD config-repo functions",
+	Long:      `Functions to help development of config-repos in GoCD (pipeline configs as code)`,
+	ValidArgs: []string{"syntax", "fetch", "preflight", "help"}, // bash-completion
 }
 
 func init() {

--- a/cmd/configrepo/syntax.go
+++ b/cmd/configrepo/syntax.go
@@ -4,13 +4,14 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/gocd-contrib/gocd-cli/plugins"
 	"github.com/gocd-contrib/gocd-cli/utils"
 	"github.com/spf13/cobra"
 )
 
-var CheckCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Checks a definition file for syntactical and structural correctness",
+var SyntaxCmd = &cobra.Command{
+	Use:   "syntax",
+	Short: "Checks one or more definition files for syntactical correctness",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		runCheck(args)
@@ -22,10 +23,9 @@ func runCheck(args []string) {
 		utils.DieLoudly(1, "You must provide a --plugin-id")
 	}
 
-	PluginJar = utils.LocatePlugin(PluginId, PluginDir)
+	PluginJar = plugins.LocatePlugin(PluginId, PluginDir)
 
 	cmdArgs := append([]string{"-jar", PluginJar, "syntax"}, args...)
-	utils.Echof("args: %v", cmdArgs)
 	cmd := exec.Command("java", cmdArgs...)
 
 	if !utils.ExecQ(cmd) {
@@ -34,5 +34,5 @@ func runCheck(args []string) {
 }
 
 func init() {
-	RootCmd.AddCommand(CheckCmd)
+	RootCmd.AddCommand(SyntaxCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,10 @@ import (
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "gocd",
-	Short: "A command-line companion to a GoCD server",
-	Long:  `A command-line helper to GoCD to help build config-repos, among other things (?)`,
+	Use:       "gocd",
+	Short:     "A command-line companion to a GoCD server",
+	Long:      `A command-line helper to GoCD to help build config-repos, among other things (?)`,
+	ValidArgs: []string{"configrepo", "help"}, // bash-completion
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -58,6 +59,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		utils.Echof("Using config file:", viper.ConfigFileUsed())
+		utils.Echofln("Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/dub/auth.go
+++ b/dub/auth.go
@@ -1,0 +1,25 @@
+package dub
+
+import (
+	"encoding/base64"
+)
+
+type AuthSpec interface {
+	Token() string
+}
+
+type BasicAuth struct {
+	User, Pass string
+}
+
+func (b *BasicAuth) Token() string {
+	return "Basic " + base64.StdEncoding.EncodeToString(b.payload())
+}
+
+func (b *BasicAuth) payload() []byte {
+	return []byte(b.User + ":" + b.Pass)
+}
+
+func NewBasicAuth(user, pass string) AuthSpec {
+	return &BasicAuth{User: user, Pass: pass}
+}

--- a/dub/auth_test.go
+++ b/dub/auth_test.go
@@ -1,0 +1,21 @@
+package dub
+
+import (
+	"testing"
+)
+
+func TestBasicAuth(t *testing.T) {
+	a := NewBasicAuth("foo", "bar")
+
+	if b, ok := a.(*BasicAuth); ok {
+		if "foo:bar" != string(b.payload()) {
+			t.Errorf("BasicAuth should concat user and pass with a colon")
+		}
+	} else {
+		t.Errorf("Expected a *BasicAuth, but got %T instead", b)
+	}
+
+	if "Basic Zm9vOmJhcg==" != a.Token() {
+		t.Errorf("BasicAuth should output auth type with base64 payload")
+	}
+}

--- a/dub/client.go
+++ b/dub/client.go
@@ -1,0 +1,71 @@
+package dub
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	native *http.Client
+}
+
+func (c *Client) Get(url string) *Request {
+	return c.buildRequest("GET", url)
+}
+
+func (c *Client) Head(url string) *Request {
+	return c.buildRequest("HEAD", url)
+}
+
+func (c *Client) Delete(url string) *Request {
+	return c.buildRequest("DELETE", url)
+}
+
+func (c *Client) Put(url string) *Request {
+	return c.buildRequest("PUT", url)
+}
+
+func (c *Client) Patch(url string) *Request {
+	return c.buildRequest("PATCH", url)
+}
+
+func (c *Client) Post(url string) *Request {
+	return c.buildRequest("POST", url)
+}
+
+func (c *Client) Connect(url string) *Request {
+	return c.buildRequest("CONNECT", url)
+}
+
+func (c *Client) Trace(url string) *Request {
+	return c.buildRequest("TRACE", url)
+}
+
+func (c *Client) Options(url string) *Request {
+	return c.buildRequest("OPTIONS", url)
+}
+
+func (c *Client) buildRequest(method, url string) *Request {
+	return &Request{Url: url, Method: method, c: c}
+}
+
+// Returns a dub.Client instance with a preconfigured http.Transport
+func New() *Client {
+	return Make(&http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 5 * time.Second,
+	})
+}
+
+// Returns a dub.Client instance allowing the user to specify their own http.Transport
+func Make(t http.RoundTripper) *Client {
+	return Wrap(&http.Client{Transport: t})
+}
+
+// Wraps an existing http.Client with a dub.Client
+func Wrap(c *http.Client) *Client {
+	return &Client{native: c}
+}

--- a/dub/client_test.go
+++ b/dub/client_test.go
@@ -1,0 +1,46 @@
+package dub
+
+import (
+	"testing"
+)
+
+func TestClientRequestMethods(t *testing.T) {
+	c := nopCl()
+	as := asserts(t)
+
+	get := c.Get("http://foo.bar")
+	as.eq("GET", get.Method)
+	as.eq("http://foo.bar", get.Url)
+
+	post := c.Post("http://foo.bar")
+	as.eq("POST", post.Method)
+	as.eq("http://foo.bar", post.Url)
+
+	put := c.Put("http://foo.bar")
+	as.eq("PUT", put.Method)
+	as.eq("http://foo.bar", put.Url)
+
+	patch := c.Patch("http://foo.bar")
+	as.eq("PATCH", patch.Method)
+	as.eq("http://foo.bar", patch.Url)
+
+	head := c.Head("http://foo.bar")
+	as.eq("HEAD", head.Method)
+	as.eq("http://foo.bar", head.Url)
+
+	delete := c.Delete("http://foo.bar")
+	as.eq("DELETE", delete.Method)
+	as.eq("http://foo.bar", delete.Url)
+
+	connect := c.Connect("http://foo.bar")
+	as.eq("CONNECT", connect.Method)
+	as.eq("http://foo.bar", connect.Url)
+
+	options := c.Options("http://foo.bar")
+	as.eq("OPTIONS", options.Method)
+	as.eq("http://foo.bar", options.Url)
+
+	trace := c.Trace("http://foo.bar")
+	as.eq("TRACE", trace.Method)
+	as.eq("http://foo.bar", trace.Url)
+}

--- a/dub/misc.go
+++ b/dub/misc.go
@@ -1,0 +1,49 @@
+package dub
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type RequestHandler func(*Request) error
+type ResponseBodyConsumer func(io.Reader) error
+type ResponseHandler func(*Response) error
+type ProgressHandler func(pr *Progress) error
+
+type Opts struct {
+	Headers      map[string][]string
+	Auth         AuthSpec
+	ContentType  string
+	OnProgress   []ProgressHandler
+	OnBeforeSend []RequestHandler
+}
+
+var methodsCanHaveBody = map[string]struct{}{
+	"put":    struct{}{},
+	"patch":  struct{}{},
+	"post":   struct{}{},
+	"delete": struct{}{},
+}
+
+func allowBody(method string) bool {
+	_, ok := methodsCanHaveBody[strings.ToLower(method)]
+	return ok
+}
+
+type lengther interface {
+	Len() int
+}
+
+type wrErr struct {
+	cause  error
+	reason string
+}
+
+func (w *wrErr) Error() string {
+	return fmt.Sprintf("%s; cause:\n  %v", w.reason, w.cause)
+}
+
+func wrapErr(cause error, reason string) error {
+	return &wrErr{cause: cause, reason: reason}
+}

--- a/dub/multipart.go
+++ b/dub/multipart.go
@@ -1,0 +1,78 @@
+package dub
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime/multipart"
+)
+
+type Multipart struct {
+	Parts []Part
+	MultipartPayload
+
+	w *multipart.Writer
+}
+
+func (m *Multipart) Read(p []byte) (int, error) {
+	if !m.MultipartPayload.Ready() {
+		return 0, errors.New("Multipart stream is not ready to read(); call Multipart.Assemble() first")
+	}
+
+	return m.MultipartPayload.Read(p)
+}
+
+func (m *Multipart) Close() error {
+	return m.MultipartPayload.Close()
+}
+
+func (m *Multipart) ContentType() string {
+	return m.w.FormDataContentType()
+}
+
+func (m *Multipart) AddField(param, value string) *Multipart {
+	m.Parts = append(m.Parts, NewFieldPart(param, value))
+	return m
+}
+
+func (m *Multipart) AddFile(param, path string) *Multipart {
+	m.Parts = append(m.Parts, NewFilePart(param, path))
+	return m
+}
+
+func (m *Multipart) AddFileStream(param, filename string, data io.Reader) *Multipart {
+	m.Parts = append(m.Parts, NewStreamPart(param, filename, data))
+	return m
+}
+
+func (m *Multipart) Len() int {
+	return m.MultipartPayload.Len()
+}
+
+func (m *Multipart) Assemble() error {
+	if m.MultipartPayload.Ready() {
+		return errors.New("This multipart stream has already been assembled")
+	}
+
+	return m.MultipartPayload.DoAssemble(m.w, m.Parts)
+}
+
+func NewPipedMultipart() *Multipart {
+	pr, pw := io.Pipe()
+	w := multipart.NewWriter(pw)
+
+	return &Multipart{
+		w:                w,
+		MultipartPayload: NewPipedPayload(pr, pw),
+	}
+}
+
+func NewAllocMultipart() *Multipart {
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+
+	return &Multipart{
+		w:                w,
+		MultipartPayload: NewAllocPayload(buf),
+	}
+}

--- a/dub/multipart_payload.go
+++ b/dub/multipart_payload.go
@@ -1,0 +1,155 @@
+package dub
+
+import (
+	"errors"
+	"io"
+	"mime/multipart"
+	"sync"
+)
+
+// Represents the constructed multipart form data payload as an io.ReadCloser.
+// Implementations will be used to build a Multipart instance for a request body.
+type MultipartPayload interface {
+	io.ReadCloser
+	Len() int
+	Ready() bool
+	DoAssemble(*multipart.Writer, []Part) error
+}
+
+func NewPipedPayload(pr *io.PipeReader, pw *io.PipeWriter) MultipartPayload {
+	return &pipedPayload{pr: pr, pw: pw}
+}
+
+func NewAllocPayload(buffer io.Reader) MultipartPayload {
+	return &allocPayload{r: buffer, ready: false}
+}
+
+// Implements a payload by allocating byte slice in memory for the entire payload.
+// Payload assembly happens synchronously, so the final content length is calculable
+// and will be set on the request. Limited to amount of memory allocable to the process.
+type allocPayload struct {
+	r     io.Reader
+	once  sync.Once
+	ready bool
+}
+
+func (p *allocPayload) Len() int {
+	if b, ok := p.r.(lengther); ok {
+		return b.Len()
+	}
+	return -1
+}
+
+func (p *allocPayload) Ready() bool {
+	return p.ready
+}
+
+func (p *allocPayload) Read(b []byte) (int, error) {
+	return p.r.Read(b)
+}
+
+func (p *allocPayload) Close() error {
+	if c, ok := p.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func (p *allocPayload) DoAssemble(w *multipart.Writer, parts []Part) (err error) {
+	p.once.Do(func() {
+		if len(parts) > 0 {
+			for _, p := range parts {
+				if err = p.Build(w); err != nil {
+					return
+				}
+			}
+		}
+
+		if err = w.Close(); err != nil {
+			return
+		}
+
+		p.ready = true
+	})
+	return
+}
+
+// This payload type will assemble concurrently as it is read, so in theory is
+// more efficient in that it does not require explicit allocation and pre-assembly.
+// Data is read as it is built, by way of io.Pipe(). As this is a streaming payload,
+// it does not have the memory limitations that allocPayload has, but is also unable
+// to report content length.
+type pipedPayload struct {
+	pr       *io.PipeReader
+	pw       *io.PipeWriter
+	asmErrCh chan error
+	once     sync.Once
+	ready    bool
+}
+
+func (p *pipedPayload) Len() int {
+	return -1
+}
+
+func (p *pipedPayload) Ready() bool {
+	return p.ready
+}
+
+func (p *pipedPayload) Read(b []byte) (int, error) {
+	if !p.ready { // prevent deadlock when write-end has yet to be written
+		return 0, errors.New("Pipe is not ready to read()")
+	}
+
+	select {
+	case err := <-p.asmErrCh:
+		if err != nil {
+			return 0, err
+		}
+		break
+	default:
+	}
+
+	return p.pr.Read(b)
+}
+
+func (p *pipedPayload) Close() error {
+	return p.pr.Close()
+}
+
+func (p *pipedPayload) DoAssemble(w *multipart.Writer, parts []Part) error {
+	p.once.Do(func() {
+		p.asmErrCh = make(chan error, 1)
+
+		go func(ec chan<- error) {
+			defer p.pw.Close()
+
+			if len(parts) > 0 {
+				for _, p := range parts {
+					if err := p.Build(w); err != nil {
+						ec <- err
+
+						close(ec)
+						return
+					}
+				}
+			}
+
+			if err := w.Close(); err != nil {
+				ec <- err
+
+				close(ec)
+				return
+			}
+
+			ec <- nil
+			close(ec)
+		}(p.asmErrCh)
+
+		p.ready = true
+	})
+
+	// Do not return the value received through the error channel
+	// or this will block on w.Write(). Assembly errors will be
+	// handled during Read(), which happens concurrently.
+	return nil
+}

--- a/dub/multipart_payload_test.go
+++ b/dub/multipart_payload_test.go
@@ -1,0 +1,55 @@
+package dub
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"testing"
+)
+
+func TestAllocPayload(t *testing.T) {
+	as := asserts(t)
+
+	b := &bytes.Buffer{}
+	w := multipart.NewWriter(b)
+	w.SetBoundary("testbound")
+
+	p := NewAllocPayload(b)
+
+	// should not be ready to read yet before assembly
+	as.not(p.Ready())
+	d, err := p.Read(make([]byte, 1))
+	as.err("EOF", err)
+	as.eq(0, d)
+
+	as.ok(p.DoAssemble(w, []Part{NewFieldPart("foo", "bar")}))
+	as.is(p.Ready())
+	as.is(p.Len() > 0)
+
+	d, err = p.Read(make([]byte, 1))
+	as.ok(err)
+	as.eq(1, d)
+}
+
+func TestPipedPayload(t *testing.T) {
+	as := asserts(t)
+	pr, pw := io.Pipe()
+	w := multipart.NewWriter(pw)
+	w.SetBoundary("testbound")
+
+	p := NewPipedPayload(pr, pw)
+
+	// should not be ready to read yet before assembly
+	as.not(p.Ready())
+	d, err := p.Read(make([]byte, 1))
+	as.err("Pipe is not ready to read()", err)
+	as.eq(0, d)
+
+	as.ok(p.DoAssemble(w, []Part{NewFieldPart("foo", "bar")}))
+	as.is(p.Ready())
+	as.eq(-1, p.Len()) // never knows the length of content
+
+	d, err = p.Read(make([]byte, 1))
+	as.ok(err)
+	as.eq(1, d)
+}

--- a/dub/multipart_test.go
+++ b/dub/multipart_test.go
@@ -1,0 +1,203 @@
+package dub
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func testMultipart() *Multipart {
+	// might be easier to debug NewAllocMultipart() if anything goes wrong
+	// but could have used NewPipedMultipart() as it might be used more
+	m := NewAllocMultipart()
+	m.w.SetBoundary("testbound")
+	return m
+}
+
+func TestAddField(t *testing.T) {
+	as := asserts(t)
+	m := testMultipart()
+
+	m.AddField("foo", "bar")
+	as.eq(1, len(m.Parts))
+
+	_, ok := m.Parts[0].(*FieldPart)
+	as.is(ok)
+	as.ok(m.Assemble())
+	as.is(m.Ready())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="foo"`,
+		``,
+		`bar`,
+		`--testbound--`,
+		``,
+	), string(b))
+}
+
+func TestAddFile(t *testing.T) {
+	as := asserts(t)
+	m := testMultipart()
+
+	m.AddFile("files[]", "testdata/file-01.txt")
+	as.eq(1, len(m.Parts))
+
+	_, ok := m.Parts[0].(*FilePart)
+	as.is(ok)
+	as.ok(m.Assemble())
+	as.is(m.Ready())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="file-01.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		"hello! this is some content.\n",
+		`--testbound--`,
+		``,
+	), string(b))
+}
+
+func TestAddFileStream(t *testing.T) {
+	as := asserts(t)
+	m := testMultipart()
+
+	m.AddFileStream("files[]", "arbitrary-data.txt", strings.NewReader("streamed content"))
+	as.eq(1, len(m.Parts))
+
+	_, ok := m.Parts[0].(*StreamPart)
+	as.is(ok)
+	as.ok(m.Assemble())
+	as.is(m.Ready())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="arbitrary-data.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		`streamed content`,
+		`--testbound--`,
+		``,
+	), string(b))
+}
+
+func TestPipedMultipartComposition(t *testing.T) {
+	as := asserts(t)
+	m := NewPipedMultipart()
+	m.w.SetBoundary("testbound")
+
+	m.AddField("foo", "bar").
+		AddFile("files[]", "testdata/file-01.txt").
+		AddFileStream("files[]", "arbitrary-data.txt", strings.NewReader("streamed content"))
+
+	as.eq(3, len(m.Parts))
+	as.ok(m.Assemble())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="foo"`,
+		``,
+		`bar`,
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="file-01.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		"hello! this is some content.\n",
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="arbitrary-data.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		`streamed content`,
+		`--testbound--`,
+		``,
+	), string(b))
+}
+
+func TestAllocMultipartComposition(t *testing.T) {
+	as := asserts(t)
+	m := NewAllocMultipart() // be explicit here in case we decide to change testMultipart()
+	m.w.SetBoundary("testbound")
+
+	m.AddField("foo", "bar").
+		AddFile("files[]", "testdata/file-01.txt").
+		AddFileStream("files[]", "arbitrary-data.txt", strings.NewReader("streamed content"))
+
+	as.eq(3, len(m.Parts))
+	as.ok(m.Assemble())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="foo"`,
+		``,
+		`bar`,
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="file-01.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		"hello! this is some content.\n",
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="arbitrary-data.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		`streamed content`,
+		`--testbound--`,
+		``,
+	), string(b))
+}
+
+func TestAllocMultipartCalculatesContentLength(t *testing.T) {
+	as := asserts(t)
+	m := NewAllocMultipart() // be explicit here in case we decide to change testMultipart()
+	m.w.SetBoundary("testbound")
+
+	as.ok(m.AddField("foo", "bar").Assemble())
+	as.eq(79, m.Len()) // show that it calculates before reading
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(79, len(b))
+	as.eq(0, m.Len()) // once consumed, length drops to zero
+}
+
+func TestPipedMultipartReportsUnknownContentLength(t *testing.T) {
+	as := asserts(t)
+	m := NewPipedMultipart()
+	m.w.SetBoundary("testbound")
+
+	as.ok(m.AddField("foo", "bar").Assemble())
+	as.eq(-1, m.Len())
+
+	b, err := ioutil.ReadAll(m)
+	as.ok(err)
+	as.eq(79, len(b))
+	as.eq(-1, m.Len()) // even after reading, does not calculate length
+}
+
+func TestMultipartOnlyReadsAfterAssembly(t *testing.T) {
+	as := asserts(t)
+	m := testMultipart()
+
+	m.AddField("foo", "bar")
+	as.not(m.Ready())
+
+	_, err := m.Read(make([]byte, 1))
+	as.err("Multipart stream is not ready to read(); call Multipart.Assemble() first", err)
+	as.ok(m.Assemble())
+
+	b, e := m.Read(make([]byte, 1))
+	as.ok(e)
+	as.eq(1, b)
+
+	as.err("This multipart stream has already been assembled", m.Assemble())
+}

--- a/dub/parts.go
+++ b/dub/parts.go
@@ -1,0 +1,74 @@
+package dub
+
+import (
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+)
+
+type Part interface {
+	Build(*multipart.Writer) error
+}
+
+type FieldPart struct {
+	param, value string
+}
+
+func (f *FieldPart) Build(w *multipart.Writer) error {
+	return w.WriteField(f.param, f.value)
+}
+
+func NewFieldPart(param, value string) *FieldPart {
+	return &FieldPart{param: param, value: value}
+}
+
+type FilePart struct {
+	param, filepath string
+}
+
+func (f *FilePart) Build(w *multipart.Writer) (err error) {
+	var file *os.File
+	var part io.Writer
+
+	if file, err = os.Open(f.filepath); err != nil {
+		return
+	}
+
+	defer file.Close()
+
+	if part, err = w.CreateFormFile(f.param, filepath.Base(f.filepath)); err != nil {
+		return
+	}
+
+	_, err = io.Copy(part, file)
+	return
+}
+
+func NewFilePart(param, path string) *FilePart {
+	return &FilePart{param: param, filepath: path}
+}
+
+type StreamPart struct {
+	param, filename string
+	data            io.Reader
+}
+
+func (s *StreamPart) Build(w *multipart.Writer) (err error) {
+	var part io.Writer
+
+	if c, ok := s.data.(io.Closer); ok {
+		defer c.Close()
+	}
+
+	if part, err = w.CreateFormFile(s.param, s.filename); err != nil {
+		return
+	}
+
+	_, err = io.Copy(part, s.data)
+	return
+}
+
+func NewStreamPart(param, filename string, data io.Reader) *StreamPart {
+	return &StreamPart{param: param, filename: filename, data: data}
+}

--- a/dub/parts_test.go
+++ b/dub/parts_test.go
@@ -1,0 +1,60 @@
+package dub
+
+import (
+	"mime/multipart"
+	"strings"
+	"testing"
+)
+
+func TestFieldPart(t *testing.T) {
+	as := asserts(t)
+	p := NewFieldPart("foo", "bar")
+
+	b := &strings.Builder{}
+	w := multipart.NewWriter(b)
+	w.SetBoundary("testbound")
+
+	as.ok(p.Build(w))
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="foo"`,
+		``,
+		`bar`,
+	), b.String())
+}
+
+func TestFilePart(t *testing.T) {
+	as := asserts(t)
+	p := NewFilePart("files[]", "testdata/file-01.txt")
+
+	b := &strings.Builder{}
+	w := multipart.NewWriter(b)
+	w.SetBoundary("testbound")
+
+	as.ok(p.Build(w))
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="file-01.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		"hello! this is some content.\n",
+	), b.String())
+}
+
+func TestStreamPart(t *testing.T) {
+	as := asserts(t)
+	p := NewStreamPart("files[]", "arbitrary-data.txt", strings.NewReader("streamed content"))
+
+	b := &strings.Builder{}
+	w := multipart.NewWriter(b)
+	w.SetBoundary("testbound")
+
+	as.ok(p.Build(w))
+	as.eq(reqfmt(
+		`--testbound`,
+		`Content-Disposition: form-data; name="files[]"; filename="arbitrary-data.txt"`,
+		`Content-Type: application/octet-stream`,
+		``,
+		`streamed content`,
+	), b.String())
+}

--- a/dub/progress.go
+++ b/dub/progress.go
@@ -1,0 +1,47 @@
+package dub
+
+import (
+	"io"
+	"net/http"
+)
+
+type Progress struct {
+	Current     int64
+	Total       int64
+	RawRequest  *http.Request
+	RawResponse *http.Response
+
+	onUpdate []ProgressHandler
+}
+
+func newProgress(total int64, handlers []ProgressHandler) *Progress {
+	return &Progress{Total: total, onUpdate: handlers}
+}
+
+type progressWriter struct {
+	progress *Progress
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.progress.Current += int64(n)
+
+	if err := p.doUpdate(); err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}
+
+func (p *progressWriter) doUpdate() error {
+	for _, h := range p.progress.onUpdate {
+		if err := h(p.progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newProgressWriter(p *Progress) io.Writer {
+	return &progressWriter{progress: p}
+}

--- a/dub/progress_test.go
+++ b/dub/progress_test.go
@@ -1,0 +1,62 @@
+package dub
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestProgressDuringUpload(t *testing.T) {
+	as := asserts(t)
+
+	c := testCl(func(req *http.Request) (*http.Response, error) {
+		if err := readOneByteAtATime(req.Body); err != nil {
+			return nil, err
+		}
+		return okResp(), nil
+	})
+
+	var result []int64
+
+	c.Post("http://test").
+		DataString("abc").
+		OnProgress(func(p *Progress) error {
+			result = append(result, p.Current)
+			return nil
+		}).Do(ignoreResponse)
+
+	as.deepEqI64([]int64{1, 2, 3}, result)
+}
+
+func TestProgressDuringDownload(t *testing.T) {
+	as := asserts(t)
+
+	c := testCl(func(req *http.Request) (*http.Response, error) {
+		return resp(200, "abc"), nil
+	})
+
+	var result []int64
+
+	c.Get("http://test").
+		Do(func(res *Response) error {
+			return res.OnProgress(func(p *Progress) error {
+				result = append(result, p.Current)
+				return nil
+			}).Consume(readOneByteAtATime)
+		})
+
+	as.deepEqI64([]int64{1, 2, 3}, result)
+}
+
+func readOneByteAtATime(data io.Reader) error {
+	for {
+		if _, err := data.Read(make([]byte, 1)); err != nil {
+			if io.EOF == err {
+				break
+			} else {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/dub/request.go
+++ b/dub/request.go
@@ -1,0 +1,185 @@
+package dub
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Request struct {
+	Url, Method string
+
+	Headers http.Header
+	Body    io.Reader
+	Raw     *http.Request
+
+	onBeforeSend []RequestHandler
+	onProgress   []ProgressHandler
+	c            *Client
+}
+
+func (r *Request) Opts(opts *Opts) *Request {
+	if len(opts.Headers) > 0 {
+		r.SetHeaders(opts.Headers)
+	}
+
+	if opts.Auth != nil {
+		r.Auth(opts.Auth)
+	}
+
+	if opts.ContentType != "" {
+		r.ContentType(opts.ContentType)
+	}
+
+	if opts.OnProgress != nil {
+		r.onProgress = opts.OnProgress
+	}
+
+	if opts.OnBeforeSend != nil {
+		r.onBeforeSend = opts.OnBeforeSend
+	}
+
+	return r
+}
+
+func (r *Request) OnProgress(handler ProgressHandler) *Request {
+	r.onProgress = append(r.onProgress, handler)
+	return r
+}
+
+func (r *Request) SetHeaders(headers map[string][]string) *Request {
+	r.Headers = make(http.Header, len(headers))
+	if len(headers) > 0 {
+		for key, val := range headers {
+			r.Headers[http.CanonicalHeaderKey(key)] = val
+		}
+	}
+	return r
+}
+
+func (r *Request) Header(key, value string) *Request {
+	r.ensureHeaders().Add(key, value)
+	return r
+}
+
+func (r *Request) ContentType(contentType string) *Request {
+	r.ensureHeaders().Set("Content-Type", contentType)
+	return r
+}
+
+func (r *Request) bodySize() int64 {
+	switch v := r.Body.(type) {
+	case lengther:
+		if size := v.Len(); size > -1 {
+			return int64(size)
+		}
+	case *os.File:
+		if i, err := v.Stat(); err == nil {
+			return i.Size()
+		}
+	}
+	return int64(-1)
+}
+
+func (r *Request) setContentLength(req *http.Request) {
+	if r.Body == nil {
+		return
+	}
+
+	req.ContentLength = r.bodySize()
+}
+
+func (r *Request) ensureHeaders() http.Header {
+	if nil == r.Headers {
+		r.Headers = make(http.Header)
+	}
+	return r.Headers
+}
+
+func (r *Request) Auth(auth AuthSpec) *Request {
+	if nil == r.Headers {
+		r.Headers = make(http.Header)
+	}
+
+	if nil == auth {
+		r.ensureHeaders().Del("Authorization")
+	} else {
+		r.ensureHeaders().Set("Authorization", auth.Token())
+	}
+
+	return r
+}
+
+func (r *Request) Data(data io.Reader) *Request {
+	r.Body = data
+
+	if m, ok := data.(*Multipart); ok {
+		r.ContentType(m.ContentType())
+	}
+	return r
+}
+
+func (r *Request) DataString(data string) *Request {
+	r.Data(strings.NewReader(data))
+	return r
+}
+
+func (r *Request) BeforeSend(handler RequestHandler) *Request {
+	r.onBeforeSend = append(r.onBeforeSend, handler)
+	return r
+}
+
+func (r *Request) Do(onResponse ResponseHandler) error {
+	if !allowBody(r.Method) && r.Body != nil {
+		return fmt.Errorf("Method `%s` does not accept a request body", r.Method)
+	}
+
+	var body io.Reader
+	var progress *Progress
+
+	if r.Body != nil {
+		if m, ok := r.Body.(*Multipart); ok {
+			if err := m.Assemble(); err != nil {
+				return wrapErr(err, "Failed to assemble multipart request body stream")
+			}
+		}
+
+		if len(r.onProgress) > 0 {
+			progress = newProgress(r.bodySize(), r.onProgress)
+			body = io.TeeReader(r.Body, newProgressWriter(progress))
+		} else {
+			body = r.Body
+		}
+	}
+
+	if req, errRq := http.NewRequest(r.Method, r.Url, body); errRq == nil {
+		r.Raw = req
+
+		if progress != nil {
+			progress.RawRequest = req
+		}
+
+		req.Header = r.Headers
+		r.setContentLength(req)
+
+		if len(r.onBeforeSend) > 0 {
+			for _, h := range r.onBeforeSend {
+				if err := h(r); err != nil {
+					return wrapErr(err, "Request.BeforeSend() hook failed")
+				}
+			}
+		}
+
+		res, errRs := r.c.native.Do(req)
+
+		if errRs != nil {
+			return errRs
+		}
+
+		return onResponse(newResp(res))
+	} else {
+		return wrapErr(errRq, "Failed to build native *http.Request")
+	}
+}

--- a/dub/request_test.go
+++ b/dub/request_test.go
@@ -1,0 +1,231 @@
+package dub
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRequestConfigByOpts(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("http://test", r.URL.String())
+		as.eq(3, len(r.Header))
+		as.eq("Dummy secret", r.Header.Get("Authorization"))
+		as.eq("text/html", r.Header.Get("Content-Type"))
+		as.eq("bar", r.Header.Get("X-Foo"))
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	req := c.Get("http://test").Opts(&Opts{
+		Headers: map[string][]string{
+			"X-Foo": {"bar"},
+		},
+		Auth:         fakeAuth("secret"),
+		ContentType:  "text/html",
+		OnProgress:   []ProgressHandler{func(p *Progress) error { return nil }},
+		OnBeforeSend: []RequestHandler{func(p *Request) error { return nil }},
+	})
+
+	as.neq(nil, req)
+	as.eq("http://test", req.Url)
+	as.eq(3, len(req.Headers))
+	as.eq("Dummy secret", req.Headers.Get("Authorization"))
+	as.eq("text/html", req.Headers.Get("Content-Type"))
+	as.eq("bar", req.Headers.Get("X-Foo"))
+	as.eq(1, len(req.onProgress))
+	as.eq(1, len(req.onBeforeSend))
+
+	as.ok(req.Do(ignoreResponse))
+	as.is(didRun)
+}
+
+func TestRequestUrl(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("http://test", r.URL.String())
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	req := c.Get("http://test")
+
+	as.neq(nil, req)
+	as.eq("http://test", req.Url)
+
+	as.ok(req.Do(ignoreResponse))
+	as.is(didRun)
+}
+
+func TestWhichRequestsAcceptBody(t *testing.T) {
+	as := asserts(t)
+
+	c := nopCl()
+	url := "http://test"
+
+	bodyDeny := []*Request{c.Get(url), c.Head(url), c.Connect(url), c.Options(url), c.Trace(url)}
+	for _, req := range bodyDeny {
+		as.err(fmt.Sprintf("Method `%s` does not accept a request body", req.Method), req.DataString("test").Do(ignoreResponse))
+	}
+
+	bodyAccept := []*Request{c.Delete(url), c.Post(url), c.Put(url), c.Patch(url)}
+	for _, req := range bodyAccept {
+		as.ok(req.DataString("test").Do(ignoreResponse))
+	}
+}
+
+func TestRequestBeforeSendAllowsNativeRequestAccess(t *testing.T) {
+	as := asserts(t)
+
+	c := nopCl()
+
+	didRun := false
+	var native *http.Request
+
+	as.ok(c.Get("http://test").BeforeSend(func(r *Request) error {
+		native = r.Raw
+		didRun = true
+		return nil
+	}).Do(ignoreResponse))
+
+	as.is(didRun)
+	as.neq(nil, native)
+}
+
+func TestRequestData(t *testing.T) {
+	as := asserts(t)
+
+	var actual string
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		b := &strings.Builder{}
+
+		as.neq(nil, r.Body)
+
+		_, err := io.Copy(b, r.Body)
+		as.ok(err)
+
+		actual = b.String()
+
+		as.eq(int64(5), r.ContentLength)
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Put("http://test").Data(strings.NewReader("hello")).Do(ignoreResponse))
+	as.is(didRun)
+	as.eq("hello", actual)
+}
+
+func TestRequestDataString(t *testing.T) {
+	as := asserts(t)
+
+	var actual string
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		b := &strings.Builder{}
+
+		as.neq(nil, r.Body)
+		_, err := io.Copy(b, r.Body)
+		as.ok(err)
+		actual = b.String()
+
+		as.eq(int64(5), r.ContentLength)
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Put("http://test").DataString("hello").Do(ignoreResponse))
+	as.is(didRun)
+	as.eq("hello", actual)
+}
+
+func TestRequestAuth(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("Dummy secret", r.Header.Get("Authorization"))
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Get("http://test").Auth(fakeAuth("secret")).Do(ignoreResponse))
+	as.is(didRun)
+}
+
+func TestRequestContentType(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("application/json", r.Header.Get("Content-Type"))
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Get("http://test").ContentType("application/json").Do(ignoreResponse))
+	as.is(didRun)
+}
+
+func TestRequestHeader(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("Bar", r.Header.Get("Foo"))
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Get("http://test").Header("Foo", "Bar").Do(ignoreResponse))
+	as.is(didRun)
+}
+
+func TestRequestSetHeaders(t *testing.T) {
+	as := asserts(t)
+
+	didRun := false
+
+	c := testCl(func(r *http.Request) (*http.Response, error) {
+		as.eq("Bar", r.Header.Get("Foo"))
+		as.eq("Bye", r.Header.Get("Hi"))
+
+		w := &strings.Builder{}
+		r.Header.Write(w) // headers can repeat (multi-value)
+		as.eq(reqfmt(
+			`Foo: Bar`,
+			`Foo: Baz`,
+			`Hi: Bye`,
+			``,
+		), w.String())
+
+		didRun = true
+		return okResp(), nil
+	})
+
+	as.ok(c.Get("http://test").SetHeaders(map[string][]string{
+		"Foo": {"Bar", "Baz"},
+		"Hi":  {"Bye"},
+	}).Do(ignoreResponse))
+	as.is(didRun)
+}

--- a/dub/response.go
+++ b/dub/response.go
@@ -1,0 +1,63 @@
+package dub
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type Response struct {
+	Status  int
+	Headers http.Header
+	Raw     *http.Response
+
+	onProgress []ProgressHandler
+}
+
+func (r *Response) IsError() bool {
+	return r.Status >= 400
+}
+
+func (r *Response) IsSuccessOrRedirect() bool {
+	return r.Status < 400 && r.Status > 199
+}
+
+func (r *Response) IsSuccess() bool {
+	return r.Status < 300 && r.Status > 199
+}
+
+func (r *Response) IsRedirect() bool {
+	return r.Status < 400 && r.Status > 299
+}
+
+func (r *Response) OnProgress(handler ProgressHandler) *Response {
+	r.onProgress = append(r.onProgress, handler)
+	return r
+}
+
+func (r *Response) Consume(doRead ResponseBodyConsumer) error {
+	defer r.Raw.Body.Close()
+
+	if len(r.onProgress) > 0 {
+		progress := newProgress(r.Raw.ContentLength, r.onProgress)
+		progress.RawResponse = r.Raw
+		return doRead(io.TeeReader(r.Raw.Body, newProgressWriter(progress)))
+	} else {
+		return doRead(r.Raw.Body)
+	}
+}
+
+func (r *Response) ReadAll() ([]byte, error) {
+	var payload []byte
+	if err := r.Consume(func(body io.Reader) (err error) {
+		payload, err = ioutil.ReadAll(body)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func newResp(r *http.Response) *Response {
+	return &Response{Raw: r, Headers: r.Header, Status: r.StatusCode}
+}

--- a/dub/response_test.go
+++ b/dub/response_test.go
@@ -1,0 +1,61 @@
+package dub
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestResponseStatus(t *testing.T) {
+	as := asserts(t)
+
+	as.is((&Response{Status: 200}).IsSuccess())
+	as.is((&Response{Status: 204}).IsSuccess())
+	as.is((&Response{Status: 204}).IsSuccessOrRedirect())
+	as.not((&Response{Status: 201}).IsRedirect())
+	as.not((&Response{Status: 200}).IsError())
+
+	as.is((&Response{Status: 302}).IsRedirect())
+	as.is((&Response{Status: 307}).IsSuccessOrRedirect())
+	as.not((&Response{Status: 300}).IsSuccess())
+	as.not((&Response{Status: 300}).IsError())
+
+	as.is((&Response{Status: 404}).IsError())
+	as.is((&Response{Status: 500}).IsError())
+	as.not((&Response{Status: 401}).IsSuccessOrRedirect())
+	as.not((&Response{Status: 403}).IsRedirect())
+	as.not((&Response{Status: 422}).IsSuccess())
+}
+
+func TestResponseConsume(t *testing.T) {
+	as := asserts(t)
+
+	r := newResp(resp(200, "hello"))
+
+	as.neq(nil, r.Raw)
+	as.neq(nil, r.Raw.Body)
+
+	var body string
+	as.ok(r.Consume(func(re io.Reader) (err error) {
+		b := &strings.Builder{}
+		if _, err = io.Copy(b, re); err == nil {
+			body = b.String()
+		}
+		return
+	}))
+
+	as.eq("hello", body)
+}
+
+func TestResponseReadAll(t *testing.T) {
+	as := asserts(t)
+
+	r := newResp(resp(200, "hello"))
+
+	as.neq(nil, r.Raw)
+	as.neq(nil, r.Raw.Body)
+
+	body, err := r.ReadAll()
+	as.ok(err)
+	as.eq("hello", string(body))
+}

--- a/dub/test_helpers_test.go
+++ b/dub/test_helpers_test.go
@@ -1,0 +1,158 @@
+package dub
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type mockRT func(*http.Request) (*http.Response, error)
+
+func (f mockRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func okResp() *http.Response {
+	return resp(200, "OK")
+}
+
+func nopRt() mockRT {
+	return mockRT(func(rq *http.Request) (rs *http.Response, e error) {
+		rs = okResp()
+		return
+	})
+}
+
+func nopCl() *Client {
+	return Make(nopRt())
+}
+
+func testCl(f func(*http.Request) (*http.Response, error)) *Client {
+	return Make(mockRT(f))
+}
+
+func resp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func ignoreResponse(res *Response) error {
+	return res.Consume(func(r io.Reader) error {
+		if r != nil {
+			io.Copy(devnull(), r)
+		}
+		return nil
+	})
+}
+
+func reqfmt(s ...string) string {
+	return strings.Join(s, "\r\n")
+}
+
+type drain struct{}
+
+func (d *drain) Write(b []byte) (int, error) { return len(b), nil }
+func (d *drain) Close() error                { return nil }
+
+func devnull() io.WriteCloser {
+	return &drain{}
+}
+
+type dummyAuth struct {
+	s string
+}
+
+func (d *dummyAuth) Token() string {
+	return "Dummy " + d.s
+}
+
+type asserter struct {
+	t *testing.T
+}
+
+func fakeAuth(s string) AuthSpec {
+	return &dummyAuth{s: s}
+}
+
+func (a *asserter) eq(expected, actual interface{}) {
+	a.t.Helper()
+	if expected != actual {
+		a.t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func (a *asserter) neq(expected, actual interface{}) {
+	a.t.Helper()
+	if expected == actual {
+		a.t.Errorf("Expected %v to not equal %v", actual, expected)
+	}
+}
+
+func (a *asserter) deepEqI64(expected, actual []int64) {
+	a.t.Helper()
+
+	if !func() bool {
+		if len(expected) != len(actual) {
+			return false
+		}
+
+		for i, v := range actual {
+			if expected[i] != v {
+				return false
+			}
+		}
+
+		return true
+	}() {
+		a.t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func (a *asserter) isNil(actual interface{}) {
+	a.t.Helper()
+	if nil != actual {
+		a.t.Errorf("Expected %v to be nil", actual)
+	}
+}
+
+func (a *asserter) err(expected string, e error) {
+	a.t.Helper()
+	if nil == e {
+		a.t.Errorf("Expected error %q, but got nil", expected)
+		return
+	}
+
+	if e.Error() != expected {
+		a.t.Errorf("Expected error %q, but got %q", expected, e)
+	}
+}
+
+func (a *asserter) ok(err error) {
+	a.t.Helper()
+	if nil != err {
+		a.t.Errorf("Expected no error, but got %v", err)
+	}
+}
+
+func (a *asserter) is(b bool) {
+	a.t.Helper()
+	if !b {
+		a.t.Errorf("Expected to be true")
+	}
+}
+
+func (a *asserter) not(b bool) {
+	a.t.Helper()
+	if b {
+		a.t.Errorf("Expected to be false")
+	}
+}
+
+func asserts(t *testing.T) *asserter {
+	return &asserter{t: t}
+}

--- a/dub/testdata/file-01.txt
+++ b/dub/testdata/file-01.txt
@@ -1,0 +1,1 @@
+hello! this is some content.

--- a/github/json.go
+++ b/github/json.go
@@ -1,0 +1,12 @@
+package github
+
+type Release struct {
+	Version    string `json:"name"`
+	Prerelease bool   `json:"prerelease"`
+	Assets     []Asset
+}
+
+type Asset struct {
+	Name string `json:"name"`
+	Url  string `json:"browser_download_url"`
+}

--- a/github/locate.go
+++ b/github/locate.go
@@ -1,0 +1,54 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/gocd-contrib/gocd-cli/utils"
+)
+
+func ResolveVersionJar(rels []Release, filterBy string, stableOnly bool) (asset *Asset, err error) {
+	if 0 == len(rels) {
+		return nil, nil
+	}
+
+	if !stableOnly && "" == filterBy {
+		return findJarAsset(&(rels[0]))
+	} else {
+		filt := buildFilter(filterBy, !stableOnly)
+		for _, r := range rels {
+			if filt(&r) {
+				return findJarAsset(&r)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Cannot find a release that matches version spec `%s` and stable-only=%t", filterBy, stableOnly)
+}
+
+func buildFilter(filterSpec string, allowPrerelease bool) func(*Release) bool {
+	if r, err := semver.ParseRange(filterSpec); err != nil {
+		utils.DieLoudly(1, "Don't know how to parse version spec `%s`: %v", filterSpec, err)
+		return nil
+	} else {
+		return func(rel *Release) bool {
+			if v, err := semver.Parse(rel.Version); err != nil {
+				utils.DieLoudly(1, "Cannot parse release version `%s`; does not conform to semantic version (%v)", err)
+				return false
+			} else {
+				return r(v) && (allowPrerelease || !rel.Prerelease)
+			}
+		}
+	}
+}
+
+func findJarAsset(rel *Release) (*Asset, error) {
+	for _, j := range rel.Assets {
+		if strings.HasSuffix(j.Name, ".jar") {
+			return &j, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not resolve jar asset for version %s", rel.Version)
+}

--- a/plugins/configrepo.go
+++ b/plugins/configrepo.go
@@ -1,0 +1,6 @@
+package plugins
+
+var ConfigRepo = PluginMap{
+	"yaml.config.plugin": NewInfo("https://api.github.com/repos/tomzo/gocd-yaml-config-plugin/releases", ">=0.8.3"),
+	"json.config.plugin": NewInfo("https://api.github.com/repos/tomzo/gocd-json-config-plugin/releases", ">=0.3.3"),
+}

--- a/plugins/types.go
+++ b/plugins/types.go
@@ -1,0 +1,48 @@
+package plugins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/gocd-contrib/gocd-cli/utils"
+)
+
+type PluginMap map[string]*Info
+
+func (pm PluginMap) Ids() []string {
+	keys := make([]string, len(pm))
+	i := 0
+	for k := range pm {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func (pm PluginMap) ShortList() string {
+	return fmt.Sprintf("[%s]", strings.Join(pm.Ids(), ", "))
+}
+
+type Info struct {
+	Url     string
+	Version string
+	Compat  semver.Range
+}
+
+func (info *Info) IsCompatible(version string) bool {
+	if v, err := semver.Parse(version); err == nil {
+		return info.Compat(v)
+	} else {
+		utils.AbortLoudly(err)
+		return false
+	}
+}
+
+func NewInfo(url string, version string) *Info {
+	sv, err := semver.ParseRange(version)
+	if err != nil {
+		utils.AbortLoudly(err)
+	}
+	return &Info{Url: url, Version: version, Compat: sv}
+}

--- a/utils/console.go
+++ b/utils/console.go
@@ -8,21 +8,27 @@ import (
 var SuppressOutput bool
 
 // Writes to STDOUT unless SuppressOutput is set.
-// Uses `printf()` formatting, but also appends a newline
-// like `println()`.
+// Uses `printf()` formatting
 func Echof(f string, t ...interface{}) {
 	if !SuppressOutput {
-		fmt.Fprintf(os.Stdout, f+"\n", t...)
+		fmt.Fprintf(os.Stdout, f, t...)
 	}
 }
 
+func Echofln(f string, t ...interface{}) {
+	Echof(f+"\n", t...)
+}
+
 // Writes to STDERR unless SuppressOutput is set.
-// Uses `printf()` formatting, but also appends a newline
-// like `println()`.
+// Uses `printf()` formatting
 func Errf(f string, t ...interface{}) {
 	if !SuppressOutput {
-		fmt.Fprintf(os.Stderr, f+"\n", t...)
+		fmt.Fprintf(os.Stderr, f, t...)
 	}
+}
+
+func Errfln(f string, t ...interface{}) {
+	Errf(f+"\n", t...)
 }
 
 // Exits with exitCode after printing message.
@@ -30,9 +36,9 @@ func Errf(f string, t ...interface{}) {
 // on value of exitCode
 func Die(exitCode int, f string, t ...interface{}) {
 	if exitCode != 0 {
-		Errf(f, t...)
+		Errfln(f, t...)
 	} else {
-		Echof(f, t...)
+		Echofln(f, t...)
 	}
 
 	os.Exit(exitCode)

--- a/utils/http.go
+++ b/utils/http.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/gocd-contrib/gocd-cli/dub"
+)
+
+func Http() *http.Client {
+	tx := &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 5 * time.Second,
+	}
+
+	return &http.Client{
+		Transport: tx,
+	}
+}
+
+func downloadProgress(dp *dub.Progress) error {
+	Echof("\r%s", strings.Repeat(" ", 35))
+	if dp.Total > -1 {
+		Echof("\r  Fetched %s/%s (%.1f%%) complete", humanize.Bytes(uint64(dp.Current)), humanize.Bytes(uint64(dp.Total)), float64(dp.Current)/float64(dp.Total)*float64(100))
+	} else {
+		Echof("\r  Fetched %s complete", humanize.Bytes(uint64(dp.Current)))
+	}
+	return nil
+}
+
+func Wget(url string, name string, destFolder string) (filepath string, err error) {
+	tmpfile := path.Join(destFolder, "_"+name+".partialdownload")
+	filepath = path.Join(destFolder, name)
+
+	Echofln("Downloading %s", url)
+
+	err = dub.New().Get(url).Do(func(res *dub.Response) (err error) {
+		var file *os.File
+
+		if file, err = os.Create(tmpfile); err != nil {
+			return err
+		}
+
+		defer file.Close()
+
+		if err = res.OnProgress(downloadProgress).Consume(func(body io.Reader) error {
+			w := bufio.NewWriter(file)
+			_, err := io.Copy(w, body)
+
+			if err == nil {
+				err = w.Flush()
+			}
+
+			return err
+		}); err != nil {
+			return err
+		}
+
+		Echofln("")
+
+		return os.Rename(tmpfile, filepath)
+	})
+
+	return filepath, err
+}


### PR DESCRIPTION
easier http client api
  - supports basic verbs (i.e., everything but not TRACE, CONNECT, OPTIONS)
  - use fluent/builder API or just pass in Opts instance
  - event hooks to handle response and progress reporting (for upload or download)
  - supports authorization (build an AuthSpec implementation for any auth type; only BasicAuth built-in for now)
  - might extract this into its own opensource project

wget abstraction for simple download

break out code from utils into new packages: plugins, github, dub
CLI knows how to parse plugin ids & versions and knows how to compare versions against requirements

CLI understands the json and yaml plugins
  - Accepts version matching via semver queries
  - checks github for releases and downloads a matching release