### PR TITLE
Implement `gocd config *` commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ set -e
 go get github.com/mitchellh/go-homedir \
   github.com/spf13/cobra \
   github.com/spf13/viper \
+  github.com/spf13/afero \
   github.com/blang/semver \
   github.com/dustin/go-humanize
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1,0 +1,72 @@
+package cfg
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gocd-contrib/gocd-cli/utils"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+const (
+	CONFIG_DIRNAME  = ".gocd"
+	CONFIG_FILENAME = "settings"
+	CONFIG_ENV_PFX  = "gocdcli"
+)
+
+type Config struct {
+	native *viper.Viper
+}
+
+func (c *Config) SetServerUrl(url string) error {
+	// to be implemented
+	return nil
+}
+
+func (c *Config) GetServerUrl() string {
+	// to be implemented
+	return ""
+}
+
+func (c *Config) SetBasicAuth(user, pass string) error {
+	// to be implemented
+	return nil
+}
+
+func (c *Config) GetAuth() map[string]string {
+	// to be implemented
+	return nil
+}
+
+func (c *Config) Consume(configFile string) {
+	if configFile != "" {
+		// Use config file from the flag.
+		c.native.SetConfigFile(configFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			utils.AbortLoudly(err)
+		}
+
+		cfgDir := filepath.Join(home, CONFIG_DIRNAME)
+		os.MkdirAll(cfgDir, os.ModePerm)
+
+		c.native.AddConfigPath(cfgDir)
+		c.native.SetConfigName(CONFIG_FILENAME)
+	}
+
+	// If a config file is found, read it in.
+	if err := c.native.ReadInConfig(); err == nil {
+		utils.Echofln("Using config file:", c.native.ConfigFileUsed())
+	}
+}
+
+func NewConfig() *Config {
+	native := viper.New()
+	native.SetEnvPrefix(CONFIG_ENV_PFX)
+	native.AutomaticEnv() // read in environment variables that match
+
+	return &Config{native: native}
+}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1,17 +1,21 @@
 package cfg
 
 import (
+	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/gocd-contrib/gocd-cli/utils"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
 const (
 	CONFIG_DIRNAME  = ".gocd"
 	CONFIG_FILENAME = "settings"
+	CONFIG_FILETYPE = "yaml"
 	CONFIG_ENV_PFX  = "gocdcli"
 )
 
@@ -19,27 +23,49 @@ type Config struct {
 	native *viper.Viper
 }
 
-func (c *Config) SetServerUrl(url string) error {
-	// to be implemented
-	return nil
+var onlyNumeric, _ = regexp.Compile(`^\d+$`)
+
+func (c *Config) SetServerUrl(urlArg string) error {
+	if "" == urlArg {
+		return errors.New("Must specify a url")
+	}
+
+	if u, err := url.Parse(urlArg); err != nil {
+		return err
+	} else {
+		if !u.IsAbs() || u.Hostname() == "" {
+			return errors.New("URL must include protocol and hostname")
+		}
+
+		if u.Port() != "" && !onlyNumeric.MatchString(u.Port()) {
+			return errors.New("Port must be numeric")
+		}
+
+		c.native.Set("server.url", u.String())
+		return c.native.WriteConfig()
+	}
 }
 
 func (c *Config) GetServerUrl() string {
-	// to be implemented
-	return ""
+	return c.native.GetString("server.url")
 }
 
 func (c *Config) SetBasicAuth(user, pass string) error {
-	// to be implemented
-	return nil
+	if "" == user || "" == pass {
+		return errors.New("Must specify user and password")
+	}
+
+	c.native.Set("auth.type", "basic")
+	c.native.Set("auth.user", user)
+	c.native.Set("auth.password", pass)
+	return c.native.WriteConfig()
 }
 
 func (c *Config) GetAuth() map[string]string {
-	// to be implemented
-	return nil
+	return c.native.GetStringMapString("auth")
 }
 
-func (c *Config) Consume(configFile string) {
+func (c *Config) Consume(configFile string) error {
 	if configFile != "" {
 		// Use config file from the flag.
 		c.native.SetConfigFile(configFile)
@@ -47,19 +73,27 @@ func (c *Config) Consume(configFile string) {
 		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
-			utils.AbortLoudly(err)
+			return err
 		}
 
 		cfgDir := filepath.Join(home, CONFIG_DIRNAME)
-		os.MkdirAll(cfgDir, os.ModePerm)
+
+		if err = os.MkdirAll(cfgDir, os.ModePerm); err != nil {
+			return err
+		}
 
 		c.native.AddConfigPath(cfgDir)
 		c.native.SetConfigName(CONFIG_FILENAME)
+		c.native.SetConfigType(CONFIG_FILETYPE)
+		configFile = filepath.Join(cfgDir, CONFIG_FILENAME+"."+CONFIG_FILETYPE)
 	}
 
 	// If a config file is found, read it in.
 	if err := c.native.ReadInConfig(); err == nil {
-		utils.Echofln("Using config file:", c.native.ConfigFileUsed())
+		utils.Echofln("Using config file: %s", c.native.ConfigFileUsed())
+		return c.native.WriteConfigAs(configFile)
+	} else {
+		return err
 	}
 }
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -1,0 +1,103 @@
+package cfg
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+)
+
+const TEST_CONF_FILE = CONFIG_FILENAME + "." + CONFIG_FILETYPE
+const TEST_URL = "http://localhost:1234/go/test"
+const TEST_USER = "admin"
+const TEST_PASSWORD = "badger"
+
+type keyVal map[string]interface{}
+
+func testConf() (*Config, afero.Fs) {
+	v := viper.New()
+	v.SetEnvPrefix(CONFIG_ENV_PFX)
+	v.AutomaticEnv()
+	fs := afero.NewMemMapFs()
+	v.SetFs(fs)
+	v.SetConfigType(CONFIG_FILETYPE)
+	v.SetConfigName(CONFIG_FILENAME)
+	v.SetConfigFile(TEST_CONF_FILE)
+	v.WriteConfigAs(TEST_CONF_FILE)
+	return &Config{native: v}, fs
+}
+
+func TestGetBasicAuth(t *testing.T) {
+	as := asserts(t)
+	c, _ := testConf()
+	c.native.Set("auth.type", "basic")
+	c.native.Set("auth.user", TEST_USER)
+	c.native.Set("auth.password", TEST_PASSWORD)
+	c.native.WriteConfig()
+
+	as.deepEq(map[string]string{
+		"type":     "basic",
+		"user":     TEST_USER,
+		"password": TEST_PASSWORD,
+	}, c.GetAuth())
+}
+
+func TestSetBasicAuth(t *testing.T) {
+	as := asserts(t)
+	c, fs := testConf()
+
+	as.configEq(make(keyVal, 0), fs)
+
+	as.ok(c.SetBasicAuth(TEST_USER, TEST_PASSWORD))
+
+	as.configEq(keyVal{
+		"auth": map[string]string{
+			"type":     "basic",
+			"user":     TEST_USER,
+			"password": TEST_PASSWORD,
+		},
+	}, fs)
+}
+
+func TestSetBasicAuthShouldValidatePrescenseOfUserAndPassword(t *testing.T) {
+	as := asserts(t)
+	c, _ := testConf()
+
+	as.err("Must specify user and password", c.SetBasicAuth("", TEST_PASSWORD))
+	as.err("Must specify user and password", c.SetBasicAuth(TEST_USER, ""))
+	as.err("Must specify user and password", c.SetBasicAuth("", ""))
+}
+
+func TestSetServerURL(t *testing.T) {
+	as := asserts(t)
+	c, fs := testConf()
+
+	as.configEq(make(keyVal, 0), fs)
+
+	as.ok(c.SetServerUrl(TEST_URL))
+
+	as.configEq(keyVal{
+		"server": map[string]string{
+			"url": TEST_URL,
+		},
+	}, fs)
+}
+
+func TestGetServerURL(t *testing.T) {
+	as := asserts(t)
+	c, _ := testConf()
+	c.native.Set("server.url", TEST_URL)
+	c.native.WriteConfig()
+
+	as.eq(TEST_URL, c.GetServerUrl())
+}
+
+func TestSetServerURLValidatesURL(t *testing.T) {
+	as := asserts(t)
+	c, _ := testConf()
+
+	as.err("Must specify a url", c.SetServerUrl(""))
+	as.err("URL must include protocol and hostname", c.SetServerUrl("foo.bar"))
+	as.err("URL must include protocol and hostname", c.SetServerUrl("http://"))
+	as.err("Port must be numeric", c.SetServerUrl("http://localhost:foo/bar"))
+}

--- a/cfg/migrations.go
+++ b/cfg/migrations.go
@@ -1,0 +1,86 @@
+package cfg
+
+import "fmt"
+
+// as the config format evolves, we will need to add config migrations here.
+// each migration is responsible for checking the prerequisite version (and
+// exiting early if not applicable) and bumping the version for the next
+// migration.
+//
+// Constructing a migration:
+//
+//   from(1).to(2).do(`Name of migration`, func(schema dict) (dict, error) {
+//     ... perform schema changes here ...
+//   })
+var migrations = []*migration{}
+
+func applyMigrations(initial dict, migrations []*migration) (migrated dict, err error) {
+	migrated = initial
+
+	for _, mig := range migrations {
+		if migrated, err = mig.run(migrated); err != nil {
+			migrated = nil
+			return
+		}
+	}
+	return
+}
+
+type migration struct {
+	fromVersion int
+	toVersion   int
+	name        string
+	body        func(dict) (dict, error)
+}
+
+func from(version int) *migration { //
+	return &migration{fromVersion: version}
+}
+
+func (m *migration) to(version int) *migration {
+	m.toVersion = version
+	return m
+}
+
+func (m *migration) do(name string, body func(dict) (dict, error)) *migration {
+	m.name = name
+	m.body = body
+	return m
+}
+
+func (m *migration) needsMigration(schema dict) bool {
+	if _, exists := schema[CONFIG_VERSION]; !exists {
+		return false
+	}
+
+	if v, ok := schema[CONFIG_VERSION].(int); !ok {
+		return false
+	} else {
+		return v == m.fromVersion
+	}
+}
+
+func (m *migration) setsVersion(schema dict) {
+	schema[CONFIG_VERSION] = m.toVersion
+}
+
+func (m *migration) run(input dict) (dict, error) {
+	if `` == m.name {
+		return nil, fmt.Errorf(`Migration %d -> %d has no name`, m.fromVersion, m.toVersion)
+	}
+
+	if nil == m.body {
+		return nil, fmt.Errorf(`Migration %q has no body`, m.name)
+	}
+
+	if !m.needsMigration(input) {
+		return input, nil
+	}
+
+	if output, err := m.body(input); err == nil {
+		m.setsVersion(output)
+		return output, nil
+	} else {
+		return nil, err
+	}
+}

--- a/cfg/migrations_test.go
+++ b/cfg/migrations_test.go
@@ -1,0 +1,125 @@
+package cfg
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestMigrations(t *testing.T) {
+	as := asserts(t)
+	c, err := makeConf(fmt.Sprintf(`%s: %d
+foo: bar
+`, CONFIG_VERSION, CURRENT_VERSION-2))
+	as.ok(err)
+
+	migs := []*migration{
+		from(CURRENT_VERSION-2).
+			to(CURRENT_VERSION-1).
+			do(`change foo to baz`, func(cfg dict) (dict, error) {
+				if v, ok := cfg[`foo`]; ok {
+					cfg[`baz`] = v
+					delete(cfg, `foo`)
+				}
+				return cfg, nil
+			}),
+
+		from(CURRENT_VERSION-1).
+			to(CURRENT_VERSION).
+			do(`baz becomes a list`, func(cfg dict) (dict, error) {
+				if v, ok := cfg[`baz`]; ok {
+					cfg[`baz`] = []interface{}{v}
+				}
+				return cfg, nil
+			}),
+	}
+
+	as.ok(c.Migrate(migs))
+	as.configEq(dict{
+		`config_version`: CURRENT_VERSION,
+		`baz`:            []string{`bar`},
+	}, c.fs)
+}
+
+func TestMigrationsDoesNotModifyConfigFileOnError(t *testing.T) {
+	as := asserts(t)
+	c, err := makeConf(fmt.Sprintf(`%s: %d
+foo: bar
+`, CONFIG_VERSION, CURRENT_VERSION-2))
+	as.ok(err)
+
+	migs := []*migration{
+		from(CURRENT_VERSION-2).
+			to(CURRENT_VERSION-1).
+			do(`change foo to baz`, func(cfg dict) (dict, error) {
+				if v, ok := cfg[`foo`]; ok {
+					cfg[`baz`] = v
+					delete(cfg, `foo`)
+				}
+				return cfg, nil
+			}),
+
+		from(CURRENT_VERSION-1).
+			to(CURRENT_VERSION).
+			do(`should blow up`, func(cfg dict) (dict, error) {
+				return nil, errors.New(`boom!`)
+			}),
+	}
+
+	as.err(`boom!`, c.Migrate(migs))
+
+	// should not change what is on disk
+	as.configEq(dict{
+		CONFIG_VERSION: CURRENT_VERSION - 2,
+		`foo`:          `bar`,
+	}, c.fs)
+}
+
+func TestOnlyMigratesWhenPrerequisiteVersionMet(t *testing.T) {
+	as := asserts(t)
+	c, err := makeConf(fmt.Sprintf(`%s: %d
+foo: bar
+`, CONFIG_VERSION, CURRENT_VERSION-1))
+	as.ok(err)
+
+	didRun := false
+	migs := []*migration{
+		from(CURRENT_VERSION-2).
+			to(CURRENT_VERSION-1).
+			do(`should not run`, func(cfg dict) (dict, error) {
+				return nil, errors.New(`should not have run`)
+			}),
+
+		from(CURRENT_VERSION-1).
+			to(CURRENT_VERSION).
+			do(`should only run this`, func(cfg dict) (dict, error) {
+				didRun = true
+				return cfg, nil
+			}),
+	}
+
+	as.ok(c.Migrate(migs))
+	as.is(didRun)
+}
+
+func TestReturnsErrorWhenVersionTooNew(t *testing.T) {
+	as := asserts(t)
+	c, err := makeConf(fmt.Sprintf(`%s: %d
+foo: bar
+`, CONFIG_VERSION, CURRENT_VERSION+1))
+	as.ok(err)
+
+	didRun := false
+	migs := []*migration{
+		from(CURRENT_VERSION).to(CURRENT_VERSION+1).do(`should not run`, func(dict) (dict, error) {
+			didRun = true
+			return nil, nil
+		}),
+	}
+
+	as.not(didRun)
+	as.err(
+		fmt.Sprintf(`%q: %d is not supported in this CLI version`, CONFIG_VERSION, CURRENT_VERSION+1),
+		c.Migrate(migs),
+	)
+}

--- a/cfg/setup.go
+++ b/cfg/setup.go
@@ -1,0 +1,12 @@
+package cfg
+
+var CfgFile string
+var conf = NewConfig()
+
+func Conf() *Config {
+	return conf
+}
+
+func Setup() {
+	Conf().Consume(CfgFile)
+}

--- a/cfg/setup.go
+++ b/cfg/setup.go
@@ -1,12 +1,11 @@
 package cfg
 
-var CfgFile string
 var conf = NewConfig()
 
 func Conf() *Config {
 	return conf
 }
 
-func Setup() error {
-	return Conf().Consume(CfgFile)
+func Setup(configFile string) (err error) {
+	return Conf().Bootstrap(configFile, migrations)
 }

--- a/cfg/setup.go
+++ b/cfg/setup.go
@@ -7,6 +7,6 @@ func Conf() *Config {
 	return conf
 }
 
-func Setup() {
-	Conf().Consume(CfgFile)
+func Setup() error {
+	return Conf().Consume(CfgFile)
 }

--- a/cfg/test_helpers_test.go
+++ b/cfg/test_helpers_test.go
@@ -1,12 +1,57 @@
 package cfg
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/spf13/afero"
 	yaml "gopkg.in/yaml.v2"
 )
+
+func writeContent(fs afero.Fs, path, content string) error {
+	if f, err := fs.OpenFile(path, os.O_CREATE|os.O_WRONLY, os.FileMode(0644)); err != nil {
+		return err
+	} else {
+		defer f.Close()
+
+		_, err = f.WriteString(content)
+		return err
+	}
+}
+
+func makeConf(content string) (*Config, error) {
+	fs := afero.NewMemMapFs()
+	v := newViper(fs)
+
+	if err := writeContent(fs, TEST_CONF_FILE, content); err != nil {
+		return nil, err
+	} else {
+		v.SetConfigFile(TEST_CONF_FILE)
+
+		if err = v.ReadInConfig(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Config{native: v, fs: fs}, nil
+}
+
+// creates a test Config instance, backed by a memory mapped afero.Fs
+// if create == true, creates an empty config file on the afero.Fs
+func testConf(create bool) *Config {
+	fs := afero.NewMemMapFs()
+	v := newViper(fs)
+
+	v.AutomaticEnv()
+	v.SetConfigName(CONFIG_FILENAME)
+	v.SetConfigFile(TEST_CONF_FILE)
+
+	if create {
+		v.WriteConfigAs(TEST_CONF_FILE)
+	}
+
+	return &Config{native: v, fs: fs}
+}
 
 func serialize(t *testing.T, v interface{}) string {
 	if b, err := yaml.Marshal(v); err != nil {
@@ -27,13 +72,10 @@ func (a *asserter) deepEq(expected, actual interface{}) {
 	a.eq(serialize(a.t, expected), serialize(a.t, actual))
 }
 
-func (a *asserter) configEq(expected keyVal, fs afero.Fs) {
+func (a *asserter) configEq(expected dict, fs afero.Fs) {
 	a.t.Helper()
-	f, e := fs.Open(TEST_CONF_FILE)
+	s, e := afero.ReadFile(fs, TEST_CONF_FILE)
 	a.ok(e)
-
-	s, err := ioutil.ReadAll(f)
-	a.ok(err)
 
 	exp, e1 := yaml.Marshal(expected)
 	a.ok(e1)

--- a/cfg/test_helpers_test.go
+++ b/cfg/test_helpers_test.go
@@ -1,0 +1,93 @@
+package cfg
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/afero"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func serialize(t *testing.T, v interface{}) string {
+	if b, err := yaml.Marshal(v); err != nil {
+		t.Errorf("Error while trying to marshal %v: %v", v, err)
+		t.FailNow()
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+type asserter struct {
+	t *testing.T
+}
+
+func (a *asserter) deepEq(expected, actual interface{}) {
+	a.t.Helper()
+	a.eq(serialize(a.t, expected), serialize(a.t, actual))
+}
+
+func (a *asserter) configEq(expected keyVal, fs afero.Fs) {
+	a.t.Helper()
+	f, e := fs.Open(TEST_CONF_FILE)
+	a.ok(e)
+
+	s, err := ioutil.ReadAll(f)
+	a.ok(err)
+
+	exp, e1 := yaml.Marshal(expected)
+	a.ok(e1)
+
+	a.eq(string(exp), string(s))
+}
+
+func (a *asserter) eq(expected, actual interface{}) {
+	a.t.Helper()
+	if expected != actual {
+		a.t.Errorf("Expected %v to equal %v", actual, expected)
+	}
+}
+
+func (a *asserter) neq(expected, actual interface{}) {
+	a.t.Helper()
+	if expected == actual {
+		a.t.Errorf("Expected %v to not equal %v", actual, expected)
+	}
+}
+
+func (a *asserter) err(expected string, e error) {
+	a.t.Helper()
+	if nil == e {
+		a.t.Errorf("Expected error %q, but got nil", expected)
+		return
+	}
+
+	if e.Error() != expected {
+		a.t.Errorf("Expected error %q, but got %q", expected, e)
+	}
+}
+
+func (a *asserter) ok(err error) {
+	a.t.Helper()
+	if nil != err {
+		a.t.Errorf("Expected no error, but got %v", err)
+	}
+}
+
+func (a *asserter) is(b bool) {
+	a.t.Helper()
+	if !b {
+		a.t.Errorf("Expected to be true")
+	}
+}
+
+func (a *asserter) not(b bool) {
+	a.t.Helper()
+	if b {
+		a.t.Errorf("Expected to be false")
+	}
+}
+
+func asserts(t *testing.T) *asserter {
+	return &asserter{t: t}
+}

--- a/cmd/config/auth_basic.go
+++ b/cmd/config/auth_basic.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/gocd-contrib/gocd-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -10,15 +11,14 @@ var BasicAuthCmd = &cobra.Command{
 	Long:  "This sets the basic authentication credentials for GoCD API requests used by this CLI tool.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		runBasicAuth(args)
+		if err := runBasicAuth(args); err != nil {
+			utils.AbortLoudly(err)
+		}
 	},
 }
 
-func runBasicAuth(args []string) {
-	// 1. get username and password arguments
-	// 2. validate non-empty strings
-	// 3. write auth to config (include type=basic + credentials)
-	conf().SetBasicAuth("user", "pass")
+func runBasicAuth(args []string) error {
+	return conf().SetBasicAuth(args[0], args[1])
 }
 
 func init() {

--- a/cmd/config/auth_basic.go
+++ b/cmd/config/auth_basic.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var BasicAuthCmd = &cobra.Command{
+	Use:   "auth-basic <user> <pass>",
+	Short: "Configures basic authentication for API requests to the GoCd server instance",
+	Long:  "This sets the basic authentication credentials for GoCD API requests used by this CLI tool.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		runBasicAuth(args)
+	},
+}
+
+func runBasicAuth(args []string) {
+	// 1. get username and password arguments
+	// 2. validate non-empty strings
+	// 3. write auth to config (include type=basic + credentials)
+}
+
+func init() {
+	RootCmd.AddCommand(BasicAuthCmd)
+}

--- a/cmd/config/auth_basic.go
+++ b/cmd/config/auth_basic.go
@@ -18,6 +18,7 @@ func runBasicAuth(args []string) {
 	// 1. get username and password arguments
 	// 2. validate non-empty strings
 	// 3. write auth to config (include type=basic + credentials)
+	conf().SetBasicAuth("user", "pass")
 }
 
 func init() {

--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"github.com/gocd-contrib/gocd-cli/utils"
+	"github.com/spf13/cobra"
+)
+
+var DeleteCmd = &cobra.Command{
+	Use:   "delete <config-key>",
+	Short: "Deletes a configured value",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runDelete(args); err != nil {
+			utils.AbortLoudly(err)
+		}
+	},
+}
+
+func runDelete(args []string) error {
+	return conf().Unset(args[0])
+}
+
+func init() {
+	RootCmd.AddCommand(DeleteCmd)
+}

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/gocd-contrib/gocd-cli/utils"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	CONFIG_DIRNAME  = ".gocd"
+	CONFIG_FILENAME = "settings"
+	CONFIG_ENV_PFX  = "gocdcli"
+)
+
+var CfgFile string
+var Config = viper.New()
+
+var RootCmd = &cobra.Command{
+	Use:       "config",
+	Short:     "GoCD CLI configuration",
+	ValidArgs: []string{"auth-basic", "server-url", "help", "clear"}, // bash-completion
+}
+
+func Setup() {
+	Config.SetEnvPrefix(CONFIG_ENV_PFX)
+	Config.AutomaticEnv() // read in environment variables that match
+
+	if CfgFile != "" {
+		// Use config file from the flag.
+		Config.SetConfigFile(CfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			utils.AbortLoudly(err)
+		}
+
+		cfgDir := filepath.Join(home, CONFIG_DIRNAME)
+		os.MkdirAll(cfgDir, os.ModePerm)
+
+		Config.AddConfigPath(cfgDir)
+		Config.SetConfigName(CONFIG_FILENAME)
+	}
+
+	// If a config file is found, read it in.
+	if err := Config.ReadInConfig(); err == nil {
+		utils.Echofln("Using config file:", Config.ConfigFileUsed())
+	}
+}

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -1,23 +1,9 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-
-	"github.com/gocd-contrib/gocd-cli/utils"
-	"github.com/mitchellh/go-homedir"
+	"github.com/gocd-contrib/gocd-cli/cfg"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
-
-const (
-	CONFIG_DIRNAME  = ".gocd"
-	CONFIG_FILENAME = "settings"
-	CONFIG_ENV_PFX  = "gocdcli"
-)
-
-var CfgFile string
-var Config = viper.New()
 
 var RootCmd = &cobra.Command{
 	Use:       "config",
@@ -25,29 +11,7 @@ var RootCmd = &cobra.Command{
 	ValidArgs: []string{"auth-basic", "server-url", "help", "clear"}, // bash-completion
 }
 
-func Setup() {
-	Config.SetEnvPrefix(CONFIG_ENV_PFX)
-	Config.AutomaticEnv() // read in environment variables that match
-
-	if CfgFile != "" {
-		// Use config file from the flag.
-		Config.SetConfigFile(CfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			utils.AbortLoudly(err)
-		}
-
-		cfgDir := filepath.Join(home, CONFIG_DIRNAME)
-		os.MkdirAll(cfgDir, os.ModePerm)
-
-		Config.AddConfigPath(cfgDir)
-		Config.SetConfigName(CONFIG_FILENAME)
-	}
-
-	// If a config file is found, read it in.
-	if err := Config.ReadInConfig(); err == nil {
-		utils.Echofln("Using config file:", Config.ConfigFileUsed())
-	}
+// convenvience method so subcommands don't need to import cfg
+func conf() *cfg.Config {
+	return cfg.Conf()
 }

--- a/cmd/config/server_url.go
+++ b/cmd/config/server_url.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/gocd-contrib/gocd-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -10,17 +11,14 @@ var ServerUrlCmd = &cobra.Command{
 	Long:  "This sets the base url for GoCD API requests used by this CLI tool. The base url includes the protocol, host, port (if applicable), and path (anything before /go, if applicable).",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runServerUrl(args)
+		if err := runServerUrl(args); err != nil {
+			utils.AbortLoudly(err)
+		}
 	},
 }
 
-func runServerUrl(args []string) {
-	// 1. get the base url string from args; probably need to validate that it's not empty
-	// 2. want to parse/validate/normalize the URL using golang's "net/url" package
-	// 3. write parsed url to config
-	//      - either as a full url
-	//      - or as individual parts (e.g. host, port, protocol, path, authString)
-	conf().SetServerUrl("argument")
+func runServerUrl(args []string) error {
+	return conf().SetServerUrl(args[0])
 }
 
 func init() {

--- a/cmd/config/server_url.go
+++ b/cmd/config/server_url.go
@@ -20,6 +20,7 @@ func runServerUrl(args []string) {
 	// 3. write parsed url to config
 	//      - either as a full url
 	//      - or as individual parts (e.g. host, port, protocol, path, authString)
+	conf().SetServerUrl("argument")
 }
 
 func init() {

--- a/cmd/config/server_url.go
+++ b/cmd/config/server_url.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var ServerUrlCmd = &cobra.Command{
+	Use:   "server-url",
+	Short: "Configures the base url for API requests to the GoCD server instance",
+	Long:  "This sets the base url for GoCD API requests used by this CLI tool. The base url includes the protocol, host, port (if applicable), and path (anything before /go, if applicable).",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runServerUrl(args)
+	},
+}
+
+func runServerUrl(args []string) {
+	// 1. get the base url string from args; probably need to validate that it's not empty
+	// 2. want to parse/validate/normalize the URL using golang's "net/url" package
+	// 3. write parsed url to config
+	//      - either as a full url
+	//      - or as individual parts (e.g. host, port, protocol, path, authString)
+}
+
+func init() {
+	RootCmd.AddCommand(ServerUrlCmd)
+}

--- a/cmd/configrepo/root.go
+++ b/cmd/configrepo/root.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gocd-contrib/gocd-cli/utils"
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,23 +1,17 @@
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-
+	"github.com/gocd-contrib/gocd-cli/cmd/config"
 	"github.com/gocd-contrib/gocd-cli/cmd/configrepo"
 	"github.com/gocd-contrib/gocd-cli/utils"
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
-
-var cfgFile string
 
 var rootCmd = &cobra.Command{
 	Use:       "gocd",
 	Short:     "A command-line companion to a GoCD server",
 	Long:      `A command-line helper to GoCD to help build config-repos, among other things (?)`,
-	ValidArgs: []string{"configrepo", "help"}, // bash-completion
+	ValidArgs: []string{"config", "configrepo", "help"}, // bash-completion
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -29,36 +23,10 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(config.Setup)
+	rootCmd.AddCommand(config.RootCmd)
 	rootCmd.AddCommand(configrepo.RootCmd)
 
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&config.CfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&utils.SuppressOutput, "quiet", "q", false, "silence output")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			utils.AbortLoudly(err)
-		}
-
-		cfgDir := filepath.Join(home, ".gocd")
-		os.MkdirAll(cfgDir, os.ModePerm)
-
-		viper.AddConfigPath(cfgDir)
-		viper.SetConfigName("settings")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		utils.Echofln("Using config file:", viper.ConfigFileUsed())
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/gocd-contrib/gocd-cli/cfg"
 	"github.com/gocd-contrib/gocd-cli/cmd/config"
 	"github.com/gocd-contrib/gocd-cli/cmd/configrepo"
 	"github.com/gocd-contrib/gocd-cli/utils"
@@ -23,10 +24,10 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(config.Setup)
+	cobra.OnInitialize(cfg.Setup)
 	rootCmd.AddCommand(config.RootCmd)
 	rootCmd.AddCommand(configrepo.RootCmd)
 
-	rootCmd.PersistentFlags().StringVarP(&config.CfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&cfg.CfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&utils.SuppressOutput, "quiet", "q", false, "silence output")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,11 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(cfg.Setup)
+	cobra.OnInitialize(func() {
+		if err := cfg.Setup(); err != nil {
+			utils.AbortLoudly(err)
+		}
+	})
 	rootCmd.AddCommand(config.RootCmd)
 	rootCmd.AddCommand(configrepo.RootCmd)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@ var rootCmd = &cobra.Command{
 	ValidArgs: []string{"config", "configrepo", "help"}, // bash-completion
 }
 
+var cfgFile string
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -25,13 +27,15 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(func() {
-		if err := cfg.Setup(); err != nil {
+		if err := cfg.Setup(cfgFile); err != nil {
 			utils.AbortLoudly(err)
+		} else {
+			utils.Echofln("Loaded config from: %s", cfg.Conf().ConfigFile())
 		}
 	})
 	rootCmd.AddCommand(config.RootCmd)
 	rootCmd.AddCommand(configrepo.RootCmd)
 
-	rootCmd.PersistentFlags().StringVarP(&cfg.CfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.gocd/settings.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&utils.SuppressOutput, "quiet", "q", false, "silence output")
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,10 @@ import (
 	"github.com/gocd-contrib/gocd-cli/cmd"
 )
 
+const (
+	VERSION = `1.0.0`
+)
+
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
Allow user to save basic auth creds and server url to the config file

TODO:

- [x] Set/Get basic auth
- [x] Set/Get server url
- [x] Clear setting
- [x] ~Clear all settings~ >> don't need this as the user can just delete the config file
- [x] Ensure format version is present, and check the version compatibility
- [x] Format migration (scaffolding for now as we don't have any migrations yet)