### PR TITLE
[Bugfix] Updating the `auth` config should replace the `auth` sub-tree instead of merging with the prior sub-tree

### DIFF
--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -79,10 +79,7 @@ func TestSetTokenAuth(t *testing.T) {
 func TestSettingAuthClearsPreviousSetting(t *testing.T) {
 	as := asserts(t)
 	c := testConf(true)
-	c.native.Set("auth.type", "basic")
-	c.native.Set("auth.user", TEST_USER)
-	c.native.Set("auth.password", TEST_PASSWORD)
-	c.native.WriteConfig()
+	c.SetBasicAuth(TEST_USER, TEST_PASSWORD)
 
 	as.deepEq(map[string]string{
 		"type":     "basic",
@@ -99,6 +96,20 @@ func TestSettingAuthClearsPreviousSetting(t *testing.T) {
 	}, c.fs)
 
 	as.ok(c.SetTokenAuth(`gah!`))
+
+	as.deepEq(map[string]string{
+		"type":  "token",
+		"token": "gah!",
+	}, c.GetAuth())
+
+	as.configEq(dict{
+		"auth": map[string]string{
+			"type":  "token",
+			"token": "gah!",
+		},
+	}, c.fs)
+
+	c.native.ReadInConfig() // ensure we refresh from disk to exclude override register
 
 	as.deepEq(map[string]string{
 		"type":  "token",


### PR DESCRIPTION
Fix issue where switching between auth config strategies merges the keys together

For example, if a user set basic auth by: `gocd config auth-basic user1 secretpass`,
the config should look like:

```yaml
auth:
  type: basic
  user: user1
  password: secretpass
```

If a user changes to token auth later, the expected behavior is that the entire `auth`
subtree should be replaced. Thus, `gocd config auth-token abc123` should yield:

```yaml
auth:
  type: token
  token: abc123
```

But instead, yielded a merged map:

```yaml
auth:
  type: token
  user: user1
  password: secretpass
  token: abc123
```

This has to do with how spf13/viper works. The solution is to do something similar to
our implementation of Unset():

  - clear override register for the top-level key and any sub-tree keys (i.e., those that
    clear the keys `auth` and those starting with `auth.`
  - create a map[string]string{} from the current config that excludes the same sub-tree
  - merge that map using `viper.MergeConfigMap()` onto an ephemeral, pristine viper instance
  - flush the merged (ephemeral) instance to disk

This commit basically modifies the internal `*Config.writeConfigExcludingKey()` method
to accept a function to allow updates to the intermediate map before flushing to disk.
This effectively lets us replace the contents of a config sub-tree.