### PR TITLE
Build fixes on Golang 1.12.9

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,2 +1,2 @@
-DOJO_DOCKER_IMAGE=kudulab/golang-dojo:1.0.0
+DOJO_DOCKER_IMAGE=kudulab/golang-dojo:1.1.0
 DOJO_WORK_INNER="/dojo/work/src/gocd-cli"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A command-line companion to GoCD. In its current state, it mostly has helpers fo
 ## Development
 
 This is a [golang](https://golang.org/) project, so if you are new to this, please set up your environment according to [this page](https://golang.org/doc/code.html#Workspaces).
+Golang version >= 1.12 is needed.
 
 To build the `gocd` binary, run the `build.sh` command:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line companion to GoCD. In its current state, it mostly has helpers fo
 ## Development
 
 This is a [golang](https://golang.org/) project, so if you are new to this, please set up your environment according to [this page](https://golang.org/doc/code.html#Workspaces).
-Golang version >= 1.12 is needed.
+Golang version >= 1.12.7 is needed.
 
 To build the `gocd` binary, run the `build.sh` command:
 

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -167,7 +167,7 @@ func TestSetServerURLValidatesURL(t *testing.T) {
 	as.err("Must specify a url", c.SetServerUrl(""))
 	as.err("server-url must include protocol and hostname", c.SetServerUrl("foo.bar"))
 	as.err("server-url must include protocol and hostname", c.SetServerUrl("http://"))
-	as.err("server-url port must be numeric", c.SetServerUrl("http://localhost:foo/bar"))
+	as.err("parse http://localhost:foo/bar: invalid port \":foo\" after host", c.SetServerUrl("http://localhost:foo/bar"))
 	as.err("server-url must end with /go", c.SetServerUrl("http://localhost:8080/bar"))
 	as.eq("", c.GetServerUrl())
 }


### PR DESCRIPTION
 * Updated docker dojo image to build with Golang 1.12 which is required now
 * Fixed a failing test