### PR TITLE
Correction for error on TestSetServerURLValidatesURL

### DIFF
--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -1,5 +1,6 @@
 package cfg
 
+
 import (
 	"os"
 	"path/filepath"

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -167,7 +167,7 @@ func TestSetServerURLValidatesURL(t *testing.T) {
 	as.err("Must specify a url", c.SetServerUrl(""))
 	as.err("server-url must include protocol and hostname", c.SetServerUrl("foo.bar"))
 	as.err("server-url must include protocol and hostname", c.SetServerUrl("http://"))
-	as.err("parse \"http://localhost:foo/bar\": invalid port \":foo\" after host", c.SetServerUrl("http://localhost:foo/bar"))
+	as.err("parse http://localhost:foo/bar: invalid port \":foo\" after host", c.SetServerUrl("http://localhost:foo/bar"))
 	as.err("server-url must end with /go", c.SetServerUrl("http://localhost:8080/bar"))
 	as.eq("", c.GetServerUrl())
 }


### PR DESCRIPTION
Since Linux, when I build, I get the following error

FAIL: TestSetServerURLValidatesURL
-> Expected error :
"parse \"http://localhost:foo/bar\": invalid port \":foo\" after host"
 -> but got :
"parse http://localhost:foo/bar: invalid port \":foo\" after host"

